### PR TITLE
Option added to skip queries of whitelisted users

### DIFF
--- a/include/audit_handler.h
+++ b/include/audit_handler.h
@@ -36,6 +36,8 @@ typedef size_t OFFSET;
 #define MAX_COM_STATUS_VARS_RECORDS 512
 
 #define MAX_OBJECT_CHAR_NUMBERS 130
+#define MAX_USER_CHAR_NUMBERS 20
+const char * retrieve_user (THD * thd);
 #define MAX_NUM_OBJECT_ELEM 256
 
 /**
@@ -78,9 +80,11 @@ public:
     ThdSesData(THD *pTHD);
     THD* getTHD () { return m_pThd;}
     const char * getCmdName () { return m_CmdName; }
+    const char * getUserName () { return m_UserName; }
 private:
     THD *m_pThd;
     const char *m_CmdName;
+    const char *m_UserName;
 protected:
     ThdSesData (const ThdSesData& );
     ThdSesData &operator =(const ThdSesData& );

--- a/src/audit_handler.cc
+++ b/src/audit_handler.cc
@@ -528,7 +528,8 @@ ssize_t Audit_json_formatter::event_format(ThdSesData* pThdData, IWriter * write
 
 
 
-ThdSesData::ThdSesData (THD *pTHD) : m_pThd (pTHD), m_CmdName(NULL)
+ThdSesData::ThdSesData (THD *pTHD) : m_pThd (pTHD), m_CmdName(NULL), m_UserName(NULL)
 {
     m_CmdName = retrieve_command (m_pThd);    
+    m_UserName = retrieve_user (m_pThd);
 }


### PR DESCRIPTION
Usage:
This has to placed in my.cnf file if queries of users john and doe are NOT to be logged.
 audit_whitelist_users=john,doe
