### PR TITLE
Adding datagram-socket functionality

### DIFF
--- a/include/audit_handler.h
+++ b/include/audit_handler.h
@@ -404,6 +404,7 @@ protected:
 
 class Audit_socket_handler: public Audit_io_handler
 {
+int sock;
 public:
 
     Audit_socket_handler() :

--- a/src/audit_plugin.cc
+++ b/src/audit_plugin.cc
@@ -528,6 +528,8 @@ static const ThdOffsets thd_offsets_arr[] =
 		{"5.5.27","b4d8ccf9348ecfe52fcf1d34b37a394d", 3812, 3840, 2364, 2696, 44, 1644},
 		//offsets for: /mysql/5.5.28/bin/mysqld (5.5.28)
 		{"5.5.28","f8922e4289a17acf0347e478f6f30705", 3812, 3840, 2364, 2696, 44, 1644},
+//offsets for datagram_socket development
+{"5.5.29","8e59768a63e8e4ece2e2acd41f375dac", 3788, 3816, 2340, 2672, 44, 1644}
 };
 
 #endif


### PR DESCRIPTION
Moved 'int sock' declaration to class definiton in the header, as it is needed in more places than with just a stream socket.
I've added only the offset for the 32bit source code distribution.

I tried a couple of if's to choose whether to print or not the newline (audit_handler.cc, around line 491). I also took a look at using the msg_delimiter but I'm still running on low steam and this is my second to last day at this workplace. Maybe you have a good idea for this?

What I gathered from rsyslog doing a proper parser for the JSON is a bit of a pain. As far as I understood you need to actually write it in weird "rsyslog C" and then compile it into the binary.
Sending the messages from the audit plugin in the current syslog format http://tools.ietf.org/html/rfc5424 or the legacy format http://tools.ietf.org/html/rfc3164 would make things easier. I'll actually see if I can make sense of the event_formatter and make an optional formatter.

I figured a month would be enough to do this properly (as a side project during work) but a bad case of sciatica renders it's toll. Last three weeks my ability to concentrate has been most lacking.
