### PR TITLE
Add MySQL5.6.13 offsets

### DIFF
--- a/src/audit_plugin.cc
+++ b/src/audit_plugin.cc
@@ -345,7 +345,9 @@ static const ThdOffsets thd_offsets_arr[] =
 		//offsets for: /mysql/5.5.32/bin/mysqld (5.5.32)
 		{"5.5.32","97829c2915124a7cfa605d3f39bea354", 6064, 6112, 3816, 4240, 88, 2592},
 		//offsets for: /mysql/5.6.12/bin/mysqld (5.6.12)
-		{"5.6.12","3a6bb81a7f1239eb810a06a3b0c5dc2a", 7816, 7864, 3960, 4400, 72, 2688}
+		{"5.6.12","3a6bb81a7f1239eb810a06a3b0c5dc2a", 7816, 7864, 3960, 4400, 72, 2688},
+        //offsets for: /mysql/5.6.13/bin/mysqld (5.6.13)
+        {"5.6.13","137c18e72cfe17d4fcacda209e405234", 7816, 7864, 3960, 4400, 72, 2688},
 
 };
 


### PR DESCRIPTION
This PR add MySQL5.6.13 Linux generic version offsets.

Pleas review this.
