### PR TITLE
new option audit_record_logins to enable logging of Connect and Quit cmds

### DIFF
--- a/src/audit_plugin.cc
+++ b/src/audit_plugin.cc
@@ -224,7 +224,7 @@ static void audit(ThdSesData *pThdData)
   if (record_logins_enable) {
       const char * cmd = pThdData->getCmdName();
       const char * user = pThdData->getUserName();
-      if (!strcasecmp(cmd, "Connect") || !strcasecmp(cmd, "Quit")) {
+      if (!strcasecmp(cmd, "Connect") || !strcasecmp(cmd, "Quit") || !strcasecmp(cmd, "Failed Login")) {
          if(user && strlen( user))
          	Audit_handler::log_audit_all(pThdData);    
          return;


### PR DESCRIPTION
Set audit_record_logins to ON, then all logins/logouts  will be logged regardless the content of the  audit_record_objs and audit_records_cmds variables.
That is, you can have ALL logins and logouts logged and at the same time you can log only selected schemas and/or tables.