### PR TITLE
Reduce the minimum required hot patching size from 14 to 6 on x86_64

### DIFF
--- a/include/hot_patch.h
+++ b/include/hot_patch.h
@@ -14,9 +14,7 @@
 
 #define GETPAGESIZE()         sysconf (_SC_PAGE_SIZE)
 
-unsigned int jump_size();
-
-int hot_patch_function(void* targetFunction, void* newFunction, void* trampolineFunction, unsigned int *trampolinesize, bool log_info);
+int hot_patch_function(void* targetFunction, void* newFunction, void* trampolineFunction, unsigned int *trampolinesize, unsigned int *usedsize, bool log_info);
 
 void remove_hot_patch_function(void* targetFunction, void* trampolineFunction, unsigned int trampolinesize, bool log_info);
 


### PR DESCRIPTION
This patch reduces the minimum required hot patching size from 14 to 6 on x86_64
if the distance from a hot-patch target function to the trampoline memory is within 2GB.
(The exact condition is: `(trampoline_memory_address - (target_function_address + 6)) between INT32_MIN and INT32_MAX`)

This patch also allocates trampoline memory under 2GB by using mmap() with MAP_32BIT when mysqld resides under 2GB.

This will rescue the following error in https://github.com/mcafee/mysql-audit/issues/72#issuecomment-33572747
```
140129 14:04:54 [Note] Audit Plugin: hot patching function: 0x7f0fc6f59aa0, trampolineFunction: 0x7f0fa44e5000 trampolinePage: 0x7f0fa44e5000
140129 14:04:54 [ERROR] Audit Plugin: unable to disassemble at address: 0x0x7f0fc6f59aaa. Found relative addressing for instruction: [jnz 0x7f0fc6f59ab5]. Aborting.
```
Relative addressing was found at 10 bytes after the beginning of the function.
It failed because 10 is smaller than the minimum hot patching size 14.
But it will not fail if the size becomes 6.
`0x7f0fa44e5000 - (0x7f0fc6f59aa0 + 6) = -581388966`, which is between `INT32_MIN` and `INT32_MAX`.
